### PR TITLE
add missing scope

### DIFF
--- a/src/js/components/examples/ScopeExample.vue
+++ b/src/js/components/examples/ScopeExample.vue
@@ -1,7 +1,7 @@
 <template>
     <code-example>
         <div class="columns is-multiline" slot="example">
-            <form @submit.prevent="validateForm('form-1')" class="columns column is-multiline is-12">
+            <form @submit.prevent="validateForm('form-1')" class="columns column is-multiline is-12" data-scope="form-1">
                 <legend>Form 1</legend>
                 <div class="column is-12">
                     <label class="label">Name</label>


### PR DESCRIPTION
Just added the "data-scope" attribute to the first form which was causing the example to underwork.
http://vee-validate.logaretm.com/examples#scope-example